### PR TITLE
Fix ERC20 standard detection

### DIFF
--- a/contracts/concretes/TokenERC20.sol
+++ b/contracts/concretes/TokenERC20.sol
@@ -10,16 +10,17 @@ contract TokenERC20 is TokenAbstraction
 
     function _isStandard(address contractAddress) internal view override virtual returns(bool){
         try IERC165(contractAddress).supportsInterface(type(IERC20).interfaceId) returns (bool result){
-            return result;
+            if(result){
+                return true;
+            }
         }catch{}
-            bool success;
-            bytes memory data;
-            (success, data) = contractAddress.staticcall(abi.encodeWithSignature("totalSupply()"));
-            if(!success) {
+
+        bool success;
+        (success, ) = contractAddress.staticcall(abi.encodeWithSignature("totalSupply()"));
+        if(!success) {
             return false;
         }
-        (success, data) = contractAddress.staticcall(abi.encodeWithSignature("balanceOf(address)", msg.sender));
-        // keep checking?
+        (success, ) = contractAddress.staticcall(abi.encodeWithSignature("balanceOf(address)", msg.sender));
         if(!success) {
             return false;
         }


### PR DESCRIPTION
## Summary
- fix `_isStandard` in `TokenERC20` to avoid returning false prematurely when `supportsInterface` is implemented but returns false

## Testing
- `npx hardhat compile`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6880eaa0981483228ca76980799a6a67